### PR TITLE
Add JMESPath filtering feature

### DIFF
--- a/cli/agnosticv_test.go
+++ b/cli/agnosticv_test.go
@@ -50,3 +50,51 @@ func TestChrooted(t *testing.T) {
 		t.Error()
 	}
 }
+
+
+func TestWalk(t *testing.T) {
+	testCases := []struct {
+		description string
+		hasFlags []string
+		count int
+	}{
+		{
+			description: "No JMES filtering",
+			hasFlags: []string{},
+			count: 12,
+		},
+		{
+			description: "key foodict is present",
+			hasFlags: []string{"foodict"},
+			count: 1,
+		},
+		{
+			description: "env_type is clientvm",
+			hasFlags: []string{"env_type == 'ocp-clientvm'"},
+			count: 2,
+		},
+		{
+			description: "Is a Babylon catalog item",
+			hasFlags: []string{"__meta__.catalog"},
+			count: 5,
+		},
+		{
+			description: "env_type is clientvm and purpose is development",
+			hasFlags: []string{
+				"env_type == 'ocp-clientvm'",
+				"purpose == 'development'",
+			},
+			count: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		result, err := findCatalogItems(".", tc.hasFlags)
+		if err != nil {
+			t.Error()
+		}
+		if len(result) != tc.count {
+			t.Error(tc.description, len(result), tc.count)
+		}
+	}
+}

--- a/cli/fixtures/gpte/OCP_CLIENTVM/dev.yaml
+++ b/cli/fixtures/gpte/OCP_CLIENTVM/dev.yaml
@@ -4,6 +4,8 @@ clientvm_instance_type: t2.medium
 
 purpose: development
 
+foodict:
+  bar: ok
 
 ##########################
 # Babylon meta variables #

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,5 +4,7 @@ go 1.14
 
 require (
 	github.com/imdario/mergo v0.3.9
+	github.com/jmespath/go-jmespath v0.4.0
 	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,6 +1,17 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/readme.adoc
+++ b/readme.adoc
@@ -31,6 +31,15 @@ The CLI `agnosticv` has the following capabilities:
 Usage of ./agnosticv:
   -debug
         Debug mode
+  -has value
+        Use with --list only. Filter catalog items using a JMESPath expression.
+        Can be used several time (act like AND).
+
+        Examples:
+        --has __meta__.catalog
+        --has "env_type == 'ocp-clientvm'"
+        --has "to_string(worker_instance_count) == '2'"
+
   -list
         List all the catalog items present in current directory.
   -merge string
@@ -39,9 +48,7 @@ Usage of ./agnosticv:
         The top directory of the agnosticv files. Files outside of this directory will not be merged.
         By default, it's empty, and the scope of the git repository is used, so you should not
         need this parameter unless your files are not in a git repository.
-
 ----
-
 
 .Using local directory
 --------------


### PR DESCRIPTION
This change, if applied, adds a new argument to the agnosticv CLI:

```
--has STRING
```

That option allows the user to filter the output of `--list` by
specifying a JSMEPath expression. The expression is applied on the
result of the merge for each catalog item and the catalog item is
included if the expression matches (result is not null and not false).

That feature will be used later in agnosticv-operator.

Examples:
```
$ agnosticv --list --has "master_instance_type == 'c5d.xlarge'"
gpte/OCP4_GETTING_STARTED_WORKSHOP/dev.yaml
gpte/OCP4_GETTING_STARTED_WORKSHOP/prod.yaml
gpte/OCP4_GETTING_STARTED_WORKSHOP/test.yaml
gpte/OCP4_WORKSHOP_PIPELINES/dev.yaml
gpte/OCP4_WORKSHOP_PIPELINES/prod.yaml
```

```
$ agnosticv --list --has "env_type == 'ocp4-cluster'" |wc -l
189
$ grep ocp4-cluster * -r|wc -l
78   # NOT the same because env_type is usually defined in common.yml
```
