### PR TITLE
Support for strategic-merge

### DIFF
--- a/cli/fixtures/.schemas/schema1.yaml
+++ b/cli/fixtures/.schemas/schema1.yaml
@@ -5,6 +5,8 @@ x-merge:
     strategy: merge
   - path: /adict/alist
     strategy: merge
+  - path: /adict/strategic_list
+    strategy: strategic-merge
 properties:
   purpose:
     type: string

--- a/cli/fixtures/test/BABYLON_EMPTY_CONFIG/common.yaml
+++ b/cli/fixtures/test/BABYLON_EMPTY_CONFIG/common.yaml
@@ -2,6 +2,11 @@
 # Agnosticd variables
 platform: babylon
 
+adict:
+  strategic_list:
+    - name: foo
+      value: common
+
 output_dir: /tmp/output_dir/{{ env_type }}-{{ guid }}
 env_type: test-empty-config
 cloud_provider: test

--- a/cli/fixtures/test/BABYLON_EMPTY_CONFIG/prod.yaml
+++ b/cli/fixtures/test/BABYLON_EMPTY_CONFIG/prod.yaml
@@ -1,6 +1,11 @@
 ---
 purpose: prod
 
+adict:
+  strategic_list:
+    - name: foo
+      value: prod
+
 #########################################
 # Meta variables for admin host scripts #
 # ALL_agnosticv.sh                      #

--- a/cli/fixtures/test/account.yaml
+++ b/cli/fixtures/test/account.yaml
@@ -4,6 +4,9 @@
 
 cloud_provider: none
 adict:
+  strategic_list:
+    - name: foo
+      value: account
   alist:
     - fromaccount
   blist:

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -12,6 +12,10 @@ import (
 	"github.com/imdario/mergo"
 )
 
+
+// MergeStrategy type to define custom merge strategies.
+// Strategy: the name of the strategy
+// Path: the path in the structure of the vars to apply the strategy against.
 type MergeStrategy struct {
 	Strategy string `json:"strategy,omitempty" yaml:"strategy,omitempty"`
 	Path string `json:"path,omitempty" yaml:"path,omitempty"`
@@ -148,6 +152,16 @@ func customStrategyMerge(final map[string]any, source map[string]any, strategy M
 				logDebug.Println("src", src)
 				logDebug.Println("dst", dst)
 				dst = append(dst, src...)
+
+			case "strategic-merge":
+				logDebug.Printf("customStrategyMerge(%v)  strategic merge", strategy)
+				logDebug.Println("src", src)
+				logDebug.Println("dst", dst)
+				dst = append(dst, src...)
+				if dst, err = strategicCleanupSlice(dst); err != nil {
+					return err
+				}
+
 			default:
 				logErr.Fatal("Unknown merge strategy for list: ", strategy.Strategy)
 			}
@@ -193,6 +207,11 @@ func customStrategyMerge(final map[string]any, source map[string]any, strategy M
 				mergo.WithOverride,
 				mergo.WithOverwriteWithEmptyValue,
 			); err != nil {
+				return err
+			}
+
+		case "strategic-merge":
+			if err := strategicMerge(dstMap, src.(map[string]any)); err != nil {
 				return err
 			}
 

--- a/cli/merge_test.go
+++ b/cli/merge_test.go
@@ -237,3 +237,31 @@ func TestMergeStrategyOverwrite(t *testing.T) {
 		t.Error("Only myspecialgroup should be present", value, expected)
 	}
 }
+
+func TestMergeStrategicMergeList(t *testing.T) {
+	rootFlag = abs("fixtures")
+	initSchemaList()
+	initMergeStrategies()
+	validateFlag = true
+	merged, _, err := mergeVars(
+		"fixtures/test/BABYLON_EMPTY_CONFIG/prod.yaml",
+		mergeStrategies,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, value, _, err := Get(merged, "/adict/strategic_list")
+	if err != nil {
+		t.Error(err)
+	}
+	expected := []any{
+		map[string]any{
+			"name": "foo",
+			"value": "prod",
+		},
+	}
+	if !reflect.DeepEqual(value, expected) {
+		t.Error("Only myspecialgroup should be present", value, expected)
+	}
+}

--- a/cli/strategic_merge.go
+++ b/cli/strategic_merge.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/imdario/mergo"
+)
+
+
+func strategicCleanupSlice(elems []any) ([]any, error) {
+	result := []any{}
+	done := map[string]int{}
+
+	for index, elem := range elems {
+		if reflect.TypeOf(elem).Kind() != reflect.Map {
+			// strategic merge works only on map, if it's not a map, just add the elem and continue
+			result = append(result, elem)
+			continue
+		}
+
+		elemMap := elem.(map[string]any)
+
+
+		if name, ok := elemMap["name"]; ok {
+			if reflect.TypeOf(elemMap["name"]).Kind() != reflect.String {
+				return result, fmt.Errorf("strategic merge cannot work if 'name' is not a string")
+			}
+			nameStr := name.(string)
+			if doneIndex, ok := done[nameStr]; ok {
+				// An element with the same name exists, replace that element
+				result1 := append(result[:doneIndex], elem)
+				result = append(result1, result[doneIndex+1:]...)
+				continue
+			}
+			// Append element
+			result = append(result, elem)
+			done[nameStr] = index
+			continue
+		}
+		result = append(result, elem)
+	}
+
+	return result, nil
+}
+func strategicCleanupMap(m map[string]any) error {
+	for key, v := range m {
+		if v == nil {
+			continue
+		}
+		if reflect.TypeOf(v).Kind() == reflect.Map {
+			vMap := v.(map[string]any)
+
+			if err := strategicCleanupMap(vMap); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if reflect.TypeOf(v).Kind() == reflect.Slice {
+			vSlice := v.([]any)
+			res, err := strategicCleanupSlice(vSlice)
+			if err != nil {
+				return err
+			}
+
+			m[key] = res
+			continue
+		}
+	}
+
+	return nil
+}
+
+func strategicMerge(dst map[string]any, src map[string]any) error {
+	if err := mergo.Merge(
+		&dst,
+		src,
+		mergo.WithOverride,
+		mergo.WithOverwriteWithEmptyValue,
+		mergo.WithAppendSlice,
+	); err != nil {
+		return err
+	}
+
+	if err := strategicCleanupMap(dst); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cli/strategic_merge_test.go
+++ b/cli/strategic_merge_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	yamljson "github.com/ghodss/yaml"
+)
+
+
+func TestCleanupSlice(t *testing.T) {
+	testCases := []struct {
+		doc []byte
+		expected []byte
+		err error
+	}{
+		{
+			doc: []byte(`[]`),
+			expected: []byte(`[]`),
+			err: nil,
+		},
+		{
+			doc: []byte(`[1,2,3]`),
+			expected: []byte(`[1,2,3]`),
+			err: nil,
+		},
+		{
+			doc: []byte(`
+- name: foo
+  value: bar
+- name: foo
+  value: bar2
+- name: foo
+  value: bar3
+`),
+			expected: []byte(`
+- name: foo
+  value: bar3
+`),
+			err: nil,
+		},
+		{
+			doc: []byte(`
+- name: foo
+  value: bar
+- name: anotherkey
+  value: bar
+- name: anotherkey2
+  value: bar
+- name: foo
+  value: bar2
+- name: foo
+  value: bar3
+`),
+			expected: []byte(`
+- name: foo
+  value: bar3
+- name: anotherkey
+  value: bar
+- name: anotherkey2
+  value: bar
+`),
+			err: nil,
+		},
+		{
+			doc: []byte(`
+- name: foo
+  value: bar
+- foo
+- foo
+- bar
+- name: foo
+  value: bar2
+- bar
+- name: foo
+  value: bar3
+- bar
+- name: foo
+  value: bar4
+`),
+			expected: []byte(`
+- name: foo
+  value: bar4
+- foo
+- foo
+- bar
+- bar
+- bar
+`),
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		doc := []any{}
+		expected := []any{}
+		if err := yamljson.Unmarshal(tc.doc, &doc); err != nil{
+			t.Fatal("cannot unmarshal", tc.doc)
+		}
+		if err := yamljson.Unmarshal(tc.expected, &expected); err != nil{
+			t.Fatal("cannot unmarshal", tc.expected)
+		}
+
+		cleanDoc, err := strategicCleanupSlice(doc)
+		if err != nil {
+			t.Fatal("error in strategicCleanupSlice: ", err)
+		}
+
+		if !reflect.DeepEqual(expected, cleanDoc) {
+			t.Error("strategicCleanupSlice: ", cleanDoc, "!=", expected)
+		}
+
+	}
+}
+
+func TestCleanupMap(t *testing.T) {
+	testCases := []struct {
+		doc []byte
+		expected []byte
+		err error
+	}{
+		{
+			doc: []byte(`{}`),
+			expected: []byte(`{}`),
+			err: nil,
+		},
+		{
+			doc: []byte(`
+foo: bar
+alist:
+  - foo
+  - name: foo
+    value: bar
+    key: present
+  - bar
+  - name: foo
+    value: bar2
+    key: changed
+`),
+			expected: []byte(`
+foo: bar
+alist:
+  - foo
+  - name: foo
+    value: bar2
+    key: changed
+  - bar
+`),
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		doc := map[string]any{}
+		expected := map[string]any{}
+		if err := yamljson.Unmarshal(tc.doc, &doc); err != nil{
+			t.Fatal("cannot unmarshal", tc.doc)
+		}
+		if err := yamljson.Unmarshal(tc.expected, &expected); err != nil{
+			t.Fatal("cannot unmarshal", tc.expected)
+		}
+
+		err := strategicCleanupMap(doc)
+		if err != nil {
+			t.Fatal("error in strategicCleanupMap: ", err)
+		}
+
+		if !reflect.DeepEqual(expected, doc) {
+			t.Error("strategicCleanupMap: ", doc, "!=", expected)
+		}
+
+	}
+}
+
+func TestStrategicMerge(t *testing.T) {
+	testCases := []struct {
+		src []byte
+		dst []byte
+		expected []byte
+		err error
+	}{
+		{
+			src: []byte(`{}`),
+			dst: []byte(`{}`),
+			expected: []byte(`{}`),
+			err: nil,
+		},
+		{
+			src: []byte(`
+foo: bar
+alist:
+  - name: foo
+    value: 1
+  - name: foo
+    value: 2
+
+`),
+			dst: []byte(`
+foo: bar2
+alist: []`),
+			expected: []byte(`
+foo: bar
+alist:
+  - name: foo
+    value: 2
+`),
+			err: nil,
+		},
+		{
+			src: []byte(`
+foo: bar
+nested:
+  foo: bar
+  alist:
+    - name: foo
+      value: 1
+    - name: foo
+      value: 2
+`),
+			dst: []byte(`foo: bar2`),
+			expected: []byte(`
+foo: bar
+nested:
+  foo: bar
+  alist:
+    - name: foo
+      value: 2
+`),
+			err: nil,
+		},
+		{
+			src: []byte(`
+foosrc: bar
+nested:
+  foo: src
+  alist:
+    - name: foo
+      value: src
+`),
+			dst: []byte(`
+foodst: bar
+nested:
+  alist:
+    - name: foo
+      value: dst
+`),
+			expected: []byte(`
+foodst: bar
+foosrc: bar
+nested:
+  foo: src
+  alist:
+    - name: foo
+      value: src
+`),
+			err: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		src := map[string]any{}
+		dst := map[string]any{}
+		expected := map[string]any{}
+		if err := yamljson.Unmarshal(tc.src, &src); err != nil{
+			t.Fatal("cannot unmarshal", tc.src)
+		}
+		if err := yamljson.Unmarshal(tc.dst, &dst); err != nil{
+			t.Fatal("cannot unmarshal", tc.dst)
+		}
+		if err := yamljson.Unmarshal(tc.expected, &expected); err != nil{
+			t.Fatal("cannot unmarshal", tc.expected)
+		}
+
+		err := strategicMerge(dst, src)
+		if err != nil {
+			t.Fatal("error in strategicCleanupMap: ", err)
+		}
+
+		if !reflect.DeepEqual(dst, expected) {
+			t.Error("strategicCleanupMap: ", dst, "!=", expected)
+		}
+
+	}
+}

--- a/readme.adoc
+++ b/readme.adoc
@@ -9,7 +9,7 @@ Agnosticv is a generic way of organizing and merging YAML files in order to mana
 Currently the project is composed of:
 
 . link:cli[CLI] `agnosticv`, a generic implementation.
-. link:https://github.com/redhat-gpte-devopsautomation/agnosticv-operator[agnosticv-operator] an OpenShift operator that uses the CLI and generates OpenShift Custom Resources for link:https://github.com/redhat-cop/babylon[Babylon] based on the content of the agnosticv repositories. The operator is more opinionated than the CLI as it expects a specific file structure in the agnosticV repository. It is used in our GPTE organization to manage our catalogs.
+. link:https://github.com/redhat-gpte-devopsautomation/agnosticv-operator[agnosticv-operator] an OpenShift operator that uses the CLI and generates OpenShift Custom Resources for link:https://github.com/redhat-cop/babylon[Babylon] based on the content of the agnosticv repositories. The operator is more opinionated than the CLI as it expects a specific file structure in the agnosticV repository. We use it to manage the catalog of our demo portal RHPDS.
 
 === Features ===
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -288,35 +288,31 @@ The value of `\\__meta__.access_control` from `prod.yaml` will take precedence a
 Here are the available custom merge strategies:
 
 |========================
-| Strategy | Can be applied to | Dictionaries | Lists | Strings / Numbers | Comment
+| Strategy | Can be applied to | Dictionaries | Lists | Strings / Numbers
 
 | `overwrite`
 | List or Dict
 | **replace**
 | **replace**
 | **replace**
-|
 
 | `merge`
 | List or Dict
 | **Merge**
 | **Append**
 | **replace**
-|
 
 | `merge-no-append`
 | Dict
 | **Merge**
 | **replace**
 | **replace**
-|
 
 | `strategic-merge`
 | List or Dict
-| **Strategic Merge**
-| **Strategic Merge**
+| **Strategic Merge** footnote:strategic-merge[Merge similar to kubernetes link:https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch[stategic merge patch]. The patch merge-key for list is `name`.]
+| **Strategic Merge** footnote:strategic-merge[]
 | **replace**
-| Merge similar to kubernetes link:https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch[stategic merge patch]. The patch merge-key for list is `name`.
 |========================
 
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,3 +1,5 @@
+:toc2:
+
 = Agnostic Vars
 
 == Description
@@ -286,25 +288,35 @@ The value of `\\__meta__.access_control` from `prod.yaml` will take precedence a
 Here are the available custom merge strategies:
 
 |========================
-| Strategy | Can be applied to | Dictionaries | Lists | Strings / Numbers
+| Strategy | Can be applied to | Dictionaries | Lists | Strings / Numbers | Comment
 
 | `overwrite`
 | List or Dict
 | **replace**
 | **replace**
 | **replace**
+|
 
 | `merge`
 | List or Dict
 | **Merge**
 | **Append**
 | **replace**
+|
 
 | `merge-no-append`
 | Dict
 | **Merge**
 | **replace**
 | **replace**
+|
+
+| `strategic-merge`
+| List or Dict
+| **Strategic Merge**
+| **Strategic Merge**
+| **replace**
+| Merge similar to kubernetes link:https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch[stategic merge patch]. The patch merge-key for list is `name`.
 |========================
 
 


### PR DESCRIPTION
This change, if applied, adds strategic-merge custom merge strategy to
agnosticv.

It can be applied to dict or list using the x-merge key in any schema.

Once this change is merged, we will update in a separate PR the default for `__meta__`
and `agnosticv_meta` variables to use 'strategic-merge' instead of 'merge'.

This code has been tested against our production agnosticV catalog and previous version v0.3.3, to produce exactly the same list and merged vars:

```
~/sync/dev/agnosticv-public/tools/test_new_version.sh ~/sync/dev/agnosticv ~/bin/agnosticv.v0.3.3 ~/bin/agnosticv.GPTEINFRA-2953
```