### PR TITLE
Use strategic-merge for babylon meta variables

### DIFF
--- a/cli/merge.go
+++ b/cli/merge.go
@@ -305,11 +305,11 @@ func initMergeStrategies() {
 	mergeStrategies = []MergeStrategy{
 		{
 			Path: "/__meta__",
-			Strategy: "merge",
+			Strategy: "strategic-merge",
 		},
 		{
 			Path: "/agnosticv_meta",
-			Strategy: "merge",
+			Strategy: "strategic-merge",
 		},
 	}
 

--- a/cli/merge_test.go
+++ b/cli/merge_test.go
@@ -195,9 +195,9 @@ func TestMerge(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !found || len(value.([]any)) != 5 {
+	if !found || len(value.([]any)) != 4 {
 		logErr.Println(value)
-		t.Error("/__meta__/secrets is missing or doesn't countain 5 elements'",
+		t.Error("/__meta__/secrets is missing or doesn't countain 4 elements'",
 			", found =", found, ", err =", err, ", #elem =", len(value.([]any)))
 	}
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -242,8 +242,8 @@ The default is the following
 | What | Dictionaries | Lists | Strings / Numbers
 
 |`\\__meta__` and `agnosticv_meta` dictionaries
-| **merge**
-| **append**
+| **strategic-merge** footnote:strategic-merge[Merge similar to kubernetes link:https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch[stategic merge patch]. The patch merge-key for list is `name`.]
+| **strategic-merge** footnote:strategic-merge[]
 | **replace**
 
 | Rest of the vars
@@ -310,7 +310,7 @@ Here are the available custom merge strategies:
 
 | `strategic-merge`
 | List or Dict
-| **Strategic Merge** footnote:strategic-merge[Merge similar to kubernetes link:https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch[stategic merge patch]. The patch merge-key for list is `name`.]
+| **Strategic Merge** footnote:strategic-merge[]
 | **Strategic Merge** footnote:strategic-merge[]
 | **replace**
 |========================


### PR DESCRIPTION
This change, if applied, change the default behavior of agnosticv to use
strategic-merge isntead of simple merge for `__meta__` and
`agnosticv_meta` variables.

We'll release a new MAJOR version of agnosticv after that change because the result of merging will be different than previous versions.