### PR TITLE
Fix slice bounds out of range

### DIFF
--- a/cli/strategic_merge.go
+++ b/cli/strategic_merge.go
@@ -12,7 +12,7 @@ func strategicCleanupSlice(elems []any) ([]any, error) {
 	result := []any{}
 	done := map[string]int{}
 
-	for index, elem := range elems {
+	for _, elem := range elems {
 		if reflect.TypeOf(elem).Kind() != reflect.Map {
 			// strategic merge works only on map, if it's not a map, just add the elem and continue
 			result = append(result, elem)
@@ -29,15 +29,20 @@ func strategicCleanupSlice(elems []any) ([]any, error) {
 			nameStr := name.(string)
 			if doneIndex, ok := done[nameStr]; ok {
 				// An element with the same name exists, replace that element
+				if doneIndex >= len(result) {
+				  return result, fmt.Errorf("index previously found is now out of bound, found:%v  len:%v", doneIndex, len(result))
+				}
 				result1 := append(result[:doneIndex], elem)
 				result = append(result1, result[doneIndex+1:]...)
 				continue
 			}
 			// Append element
+			done[nameStr] = len(result)
 			result = append(result, elem)
-			done[nameStr] = index
+
 			continue
 		}
+
 		result = append(result, elem)
 	}
 

--- a/cli/strategic_merge_test.go
+++ b/cli/strategic_merge_test.go
@@ -39,6 +39,32 @@ func TestCleanupSlice(t *testing.T) {
 `),
 			err: nil,
 		},
+		// Test when there are several reductions to make
+		{
+			doc: []byte(`
+- name: foo
+  value: bar
+- name: foo
+  value: bar2
+- name: foo
+  value: bar2
+- name: foo2
+  value: bar
+- name: foo
+  value: bar3
+- name: foo2
+  value: bar2
+- name: foo2
+  value: bar3
+`),
+			expected: []byte(`
+- name: foo
+  value: bar3
+- name: foo2
+  value: bar3
+`),
+			err: nil,
+		},
 		{
 			doc: []byte(`
 - name: foo

--- a/tools/test_new_version.sh
+++ b/tools/test_new_version.sh
@@ -39,8 +39,8 @@ for ci in $($cli1 --list); do
 	diff -u <($cli1 --merge $ci) <($cli2 --merge $ci) > /dev/null
 	if [ $? != 0 ]; then
 		echo "NO"
-		diff -u <($cli1 --merge $ci) <($cli2 --merge $ci)
-		exit 2
+		diff -y --color=always <($cli1 --merge $ci) <($cli2 --merge $ci)
+		#exit 2
 	fi
 
 	echo YES


### PR DESCRIPTION
see GPTEINFRA-3300

This change fixes the following error that occurs when there are
multiple slice reductions to execute:

```
panic: runtime error: slice bounds out of range [8:7]

goroutine 1 [running]:
main.strategicCleanupSlice({0xc000448800, 0xd, 0x1?})
        /home/fridim/sync/dev/agnosticv-public/cli/strategic_merge.go:33 +0x67d
main.strategicCleanupMap(0x7287c0?)
        /home/fridim/sync/dev/agnosticv-public/cli/strategic_merge.go:62 +0x194
main.strategicMerge(0xc000386ea0, 0x7a05c4?)
        /home/fridim/sync/dev/agnosticv-public/cli/strategic_merge.go:86 +0xca
main.customStrategyMerge(0xc0003d2180?, 0xc00043b6f8?, {{0xc0002ec9b0?, 0x7?}, {0xc0002ec9a0?, 0x0?}})
        /home/fridim/sync/dev/agnosticv-public/cli/merge.go:214 +0xd85
main.mergeVars({0xc0003c4210, 0x24}, {0xc00038b180, 0x3, 0x519daa?})
        /home/fridim/sync/dev/agnosticv-public/cli/merge.go:284 +0x7ad
main.findCatalogItems.func1({0xc0003c4210, 0x24}, {0x82fa48?, 0xc00033c820?}, {0x0?, 0x0?})
        /home/fridim/sync/dev/agnosticv-public/cli/agnosticv.go:243 +0x32f
path/filepath.walk({0xc0003c4210, 0x24}, {0x82fa48, 0xc00033c820}, 0xc00043be10)
        /usr/lib/go/src/path/filepath/path.go:418 +0x123
path/filepath.walk({0xc0004c4180, 0x1b}, {0x82fa48, 0xc00033c0d0}, 0xc00043be10)
        /usr/lib/go/src/path/filepath/path.go:442 +0x285
path/filepath.walk({0xc0003f61e8, 0x4}, {0x82fa48, 0xc000313ee0}, 0xc00043be10)
        /usr/lib/go/src/path/filepath/path.go:442 +0x285
path/filepath.walk({0x7995f8, 0x1}, {0x82fa48, 0xc0004c69c0}, 0xc00043be10)
        /usr/lib/go/src/path/filepath/path.go:442 +0x285
path/filepath.Walk({0x7995f8, 0x1}, 0xc000175e10)
        /usr/lib/go/src/path/filepath/path.go:505 +0x6c
main.findCatalogItems({0xc00001c094, 0x1f}, {0xc000099960, 0x1, 0x1}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...})
        /home/fridim/sync/dev/agnosticv-public/cli/agnosticv.go:219 +0x272
main.main()
        /home/fridim/sync/dev/agnosticv-public/cli/agnosticv.go:491 +0x15c
```