### PR TITLE
Use deepcopy to avoid duplicate elements

### DIFF
--- a/cli/fixtures/.schemas/schema1.yaml
+++ b/cli/fixtures/.schemas/schema1.yaml
@@ -3,9 +3,14 @@ type: object
 x-merge:
   - path: /alist
     strategy: merge
+
   - path: /adict/alist
     strategy: merge
+
   - path: /adict/strategic_list
+    strategy: strategic-merge
+
+  - path: /strategic_dict
     strategy: strategic-merge
 properties:
   purpose:

--- a/cli/fixtures/.schemas/schema2.yaml
+++ b/cli/fixtures/.schemas/schema2.yaml
@@ -3,8 +3,12 @@ type: object
 x-merge:
   - path: /this/doesntexist/anywhere/and/its/ok
     strategy: merge
+
   - path: /__meta__/access_control
     strategy: overwrite
+
+  - path: /__meta__/catalog
+    strategy: strategic-merge
 properties:
   __meta__:
     type: object

--- a/cli/fixtures/test/BABYLON_EMPTY_CONFIG/common.yaml
+++ b/cli/fixtures/test/BABYLON_EMPTY_CONFIG/common.yaml
@@ -2,6 +2,8 @@
 # Agnosticd variables
 platform: babylon
 
+strategic_dict:
+  alist: ["3", "4"]
 adict:
   strategic_list:
     - name: foo

--- a/cli/fixtures/test/account.yaml
+++ b/cli/fixtures/test/account.yaml
@@ -3,6 +3,9 @@
 # agnosticv catalog_item false
 
 cloud_provider: none
+strategic_dict:
+  alist: ["1", "2"]
+
 adict:
   strategic_list:
     - name: foo
@@ -27,3 +30,8 @@ __meta__:
     scm_url: https://github.com/redhat-cop/agnosticd.git
     scm_type: git
     type: agnosticd
+
+  catalog:
+    keywords:
+      - keyword1
+      - keyword2

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5
 	github.com/imdario/mergo v0.3.12
 	github.com/jmespath/go-jmespath v0.4.0
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -29,6 +29,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/cli/merge_test.go
+++ b/cli/merge_test.go
@@ -262,6 +262,23 @@ func TestMergeStrategicMergeList(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(value, expected) {
-		t.Error("Only myspecialgroup should be present", value, expected)
+		t.Error("Only prod should be present", value, expected)
+	}
+
+	_, value, _, err = Get(merged, "/strategic_dict/alist")
+	if err != nil {
+		t.Error(err)
+	}
+	expected = []any{"1", "2", "3", "4"}
+	if !reflect.DeepEqual(value, expected) {
+		t.Error("lists do not match", value, expected)
+	}
+	_, value, _, err = Get(merged, "/__meta__/catalog/keywords")
+	if err != nil {
+		t.Error(err)
+	}
+	expected = []any{"keyword1", "keyword2"}
+	if !reflect.DeepEqual(value, expected) {
+		t.Error("lists do not match", value, expected)
 	}
 }


### PR DESCRIPTION
GPTEINFRA-3301

Merge strategies being applied one after the other, when you consider the following:

```
x-merge:
- path: /__meta__
  strategy: merge
- path: /__meta__/catalog
  strategy: strategic-merge
```

and the variables:

```
__meta__:
  catalog:
    keywords:
      - keyword1
      - keyword2
```

the result of agnosticv merge is:

```
__meta__:
  catalog:
    keywords:
      - keyword1
      - keyword2
      - keyword1
      - keyword2
```

Expected:

```
__meta__:
  catalog:
    keywords:
      - keyword1
      - keyword2

```