### PR TITLE
Add version to build

### DIFF
--- a/cli/agnosticv.go
+++ b/cli/agnosticv.go
@@ -31,6 +31,12 @@ var mergeFlag string
 var debugFlag bool
 var rootFlag string
 var validateFlag bool
+var versionFlag bool
+
+// Build info
+var Version = "development"
+var buildTime = "undefined"
+var buildCommit = "HEAD"
 
 // Methods to be able to use the flag multiple times
 func (i *arrayFlags) String() string {
@@ -81,8 +87,16 @@ Examples:
 	flag.StringVar(&rootFlag, "root", "", `The top directory of the agnosticv files. Files outside of this directory will not be merged.
 By default, it's empty, and the scope of the git repository is used, so you should not
 need this parameter unless your files are not in a git repository, or if you want to use a subdir. Use -root flag with -merge.`)
+	flag.BoolVar(&versionFlag, "version", false, "Print build version.")
 
 	flag.Parse()
+
+	if versionFlag {
+		fmt.Println("Version:", Version)
+		fmt.Println("Build time:", buildTime)
+		fmt.Println("Build commit:", buildCommit)
+		os.Exit(0)
+	}
 
 	if len(hasFlags) > 0 && listFlag == false {
 		flag.PrintDefaults()

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -3,6 +3,7 @@
 
 echo -n "Version? "
 read version
+export CGO_ENABLED=0
 set -x -e -u -o pipefail
 gox --output="build/agnosticv_{{.OS}}_{{.Arch}}"  -ldflags="-X 'main.Version=${version}' -X 'main.buildTime=$(date -u)' -X 'main.buildCommit=$(git rev-parse HEAD)'"
 env GOOS=darwin GOARCH=arm64 go build -ldflags="-X 'main.Version=${version}' -X 'main.buildTime=$(date -u)' -X 'main.buildCommit=$(git rev-parse HEAD)'" -o build/agnosticv_darwin_arm64

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+
+echo -n "Version? "
+read version
+set -x -e -u -o pipefail
+gox --output="build/agnosticv_{{.OS}}_{{.Arch}}"  -ldflags="-X 'main.Version=${version}' -X 'main.buildTime=$(date -u)' -X 'main.buildCommit=$(git rev-parse HEAD)'"
+env GOOS=darwin GOARCH=arm64 go build -ldflags="-X 'main.Version=${version}' -X 'main.buildTime=$(date -u)' -X 'main.buildCommit=$(git rev-parse HEAD)'" -o build/agnosticv_darwin_arm64

--- a/cli/readme.adoc
+++ b/cli/readme.adoc
@@ -9,7 +9,8 @@ go build -o build/agnosticv
 For releases, use link:https://github.com/mitchellh/gox[gox] to build all target archs:
 
 ----
-$ gox --output="build/agnosticv_{{.OS}}_{{.Arch}}"
+$ VERSION=...
+$ gox --output="build/agnosticv_{{.OS}}_{{.Arch}}"  -ldflags="-X 'main.Version=${VERSION}' -X 'main.buildTime=$(date -u)' -X 'main.buildCommit=$(git rev-parse HEAD)'"
 Number of parallel builds: 7
 
 -->    darwin/amd64: github.com/redhat-cop/agnosticv/cli
@@ -37,7 +38,7 @@ Number of parallel builds: 7
 For Mach ARM:
 
 ----
-env GOOS=darwin GOARCH=arm64 go build  -o build/agnosticv_darwin_arm64
+env GOOS=darwin GOARCH=arm64 go build -ldflags="-X 'main.Version=${VERSION}' -X 'main.buildTime=$(date -u)' -X 'main.buildCommit=$(git rev-parse HEAD)'" -o build/agnosticv_darwin_arm64
 ----
 
 Then attach the binaries to the release in github.


### PR DESCRIPTION
Add the -versionflag:

```
❯ ./build/agnosticv_linux_amd64 -version
Version: v0.4.1
Build time: Wed May 11 12:05:57 PM UTC 2022
Build commit: e6e6bb635f4e840c1b2c0244d36c1b9aa122cb4f
```