### PR TITLE
Fix load_into bug when dest dict has other keys

### DIFF
--- a/cli/agnosticv_test.go
+++ b/cli/agnosticv_test.go
@@ -311,7 +311,7 @@ func TestWalk(t *testing.T) {
 		{
 			description: "Is a Babylon catalog item",
 			hasFlags:    []string{"__meta__.catalog"},
-			count:       5,
+			count:       7,
 		},
 		{
 			description: "env_type is clientvm and purpose is development",

--- a/cli/agnosticv_test.go
+++ b/cli/agnosticv_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -620,6 +619,7 @@ func TestLoadInto(t *testing.T) {
 	m, _, _ := mergeVars("fixtures/test/BABYLON_EMPTY_CONFIG/dev.yaml", mergeStrategies)
 	_, value, _, _ := Get(m, "/__meta__/catalog")
 
+
 	// Ensure other keys are still there
 	// 3 keys initially, including .description that will be overriden
 	// +1 key from the related_file load_into (descriptionFormat)
@@ -627,5 +627,9 @@ func TestLoadInto(t *testing.T) {
 	elems := len(value.(map[string]any))
 	if elems != 4 {
 		t.Error("__meta__.catalog should have 4 keys after merging, found", elems)
+	}
+
+	if value.(map[string]any)["description"] != "test adoc content\n" {
+		t.Error("__meta__.catalog.description is not correct")
 	}
 }

--- a/cli/agnosticv_test.go
+++ b/cli/agnosticv_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -608,5 +609,23 @@ func TestFindRoot(t *testing.T) {
 		if result != tc.result {
 			t.Error("with", tc.path, ":", result, "!=", tc.result)
 		}
+	}
+}
+
+func TestLoadInto(t *testing.T) {
+	rootFlag = abs("fixtures")
+	initConf(rootFlag)
+	validateFlag = true
+	initSchemaList()
+	m, _, _ := mergeVars("fixtures/test/BABYLON_EMPTY_CONFIG/dev.yaml", mergeStrategies)
+	_, value, _, _ := Get(m, "/__meta__/catalog")
+
+	// Ensure other keys are still there
+	// 3 keys initially, including .description that will be overriden
+	// +1 key from the related_file load_into (descriptionFormat)
+	// 3 + 1 = 4
+	elems := len(value.(map[string]any))
+	if elems != 4 {
+		t.Error("__meta__.catalog should have 4 keys after merging, found", elems)
 	}
 }

--- a/cli/fixtures/.agnosticv.yaml
+++ b/cli/fixtures/.agnosticv.yaml
@@ -4,6 +4,12 @@ related_files:
 
 # For any catalog item, consider those in same directory as related files:
 related_files_v2:
+  - file: description.adoc
+    load_into: /__meta__/catalog
+    content_key: description
+    set:
+      descriptionFormat: asciidoc
+
   - file: service-ready-message-template.html.j2
     load_into: /__meta__/service_ready
     content_key: template

--- a/cli/fixtures/test/BABYLON_EMPTY_CONFIG/description.adoc
+++ b/cli/fixtures/test/BABYLON_EMPTY_CONFIG/description.adoc
@@ -1,0 +1,1 @@
+test adoc content

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -414,10 +414,22 @@ func mergeVars(p string, mergeStrategies []MergeStrategy) (map[string]any, []Inc
 				if err != nil {
 					logErr.Fatalf("Error reading related file %s: %v", relatedPath, err)
 				}
+				temp := map[string]any{}
 
 				content[related.ContentKey] = string(relatedContent)
-				if err := SetRelative(final, related.LoadInto, content); err != nil {
+				if err := SetRelative(temp, related.LoadInto, content); err != nil {
 					logErr.Fatalf("Error SetRelative: %v", err)
+				}
+
+				// Merge temp into final using mergo
+				if err := mergo.Merge(
+					&final,
+					temp,
+					mergo.WithOverride,
+					mergo.WithOverwriteWithEmptyValue,
+					mergo.WithAppendSlice,
+				); err != nil {
+					return final, mergeList, err
 				}
 			}
 		}


### PR DESCRIPTION
Use merge instead of replacing the destination path set with `load_into`

- Add a test to cover this case