### PR TITLE
New feature: use other catalog items as included files

### DIFF
--- a/cli/agnosticv.go
+++ b/cli/agnosticv.go
@@ -164,9 +164,9 @@ need this parameter unless your files are not in a git repository, or if you wan
 			fmt.Fprintln(output, "Error:", err)
 			return controlFlow{true, 1}
 		}
-		
+
 		dirFlag = filepath.Clean(dirFlag) // line to clean dirFlag
-		
+
 	} else {
 		// Default to current directory
 		var err error
@@ -218,7 +218,6 @@ need this parameter unless your files are not in a git repository, or if you wan
 			return controlFlow{true, 2}
 		}
 	}
-
 
 	// Do not perform git operations when listing
 	if listFlag {
@@ -382,9 +381,14 @@ func extendMergeListWithRelated(pAbs string, mergeList []Include) []Include {
 func findCatalogItems(workdir string, hasFlags []string, relatedFlags []string, orRelatedFlags []string) ([]string, error) {
 	logDebug.Println("findCatalogItems(", workdir, hasFlags, ")")
 	result := []string{}
+	// save current dir
+	prevDir, _ := os.Getwd()
 	if err := os.Chdir(workdir); err != nil {
 		return result, err
 	}
+	// Restore the current directory at the end of the function
+	defer os.Chdir(prevDir)
+
 	if rootFlag == "" {
 		rootFlag = findRoot(workdir)
 	}

--- a/cli/agnosticv.go
+++ b/cli/agnosticv.go
@@ -387,7 +387,11 @@ func findCatalogItems(workdir string, hasFlags []string, relatedFlags []string, 
 		return result, err
 	}
 	// Restore the current directory at the end of the function
-	defer os.Chdir(prevDir)
+	defer func() {
+		if err := os.Chdir(prevDir); err != nil {
+			logErr.Printf("%v\n", err)
+		}
+	}()
 
 	if rootFlag == "" {
 		rootFlag = findRoot(workdir)

--- a/cli/agnosticv_test.go
+++ b/cli/agnosticv_test.go
@@ -243,7 +243,11 @@ func TestIsPathCatalogItem(t *testing.T) {
 func TestWalk(t *testing.T) {
 	prevDir, _ := os.Getwd()
 	// Restore the current directory at the end of the function
-	defer os.Chdir(prevDir)
+	defer func() {
+		if err := os.Chdir(prevDir); err != nil {
+			logErr.Printf("%v\n", err)
+		}
+	}()
 
 	rootFlag = abs("fixtures")
 	initConf(rootFlag)

--- a/cli/fixtures/gpte/OCP_CLIENTVM/notcatalogitem.yaml
+++ b/cli/fixtures/gpte/OCP_CLIENTVM/notcatalogitem.yaml
@@ -1,7 +1,6 @@
 ---
 #agnosticv catalog_item false
 #include ../../includes/include1.yaml
-#include /includes/test1.yaml
 key: value
 key2: value2
 from_include: notcatalogitem

--- a/cli/fixtures/test/BABYLON_EMPTY_CONFIG_AWS/description.adoc
+++ b/cli/fixtures/test/BABYLON_EMPTY_CONFIG_AWS/description.adoc
@@ -1,0 +1,1 @@
+from description.adoc

--- a/cli/fixtures/test/foo/prod.yaml
+++ b/cli/fixtures/test/foo/prod.yaml
@@ -1,0 +1,1 @@
+#include ../BABYLON_EMPTY_CONFIG_AWS/prod.yaml

--- a/cli/includes.go
+++ b/cli/includes.go
@@ -185,7 +185,7 @@ func parseAllIncludes(path string, done map[string]bool) ([]Include, map[string]
 				return []Include{}, done, err
 			}
 
-			innerIncludes := []Include{}
+			var innerIncludes []Include
 			var innerDone map[string]bool
 			if isCatalogItem(rootFlag, include.path) {
 				innerIncludes, err = getMergeList(include.path)

--- a/cli/includes.go
+++ b/cli/includes.go
@@ -184,11 +184,22 @@ func parseAllIncludes(path string, done map[string]bool) ([]Include, map[string]
 			if err != nil {
 				return []Include{}, done, err
 			}
-			innerIncludes, innerDone, err := parseAllIncludes(include.path, done)
-			done = innerDone
 
-			if err != nil {
-				return []Include{}, done, err
+			innerIncludes := []Include{}
+			var innerDone map[string]bool
+			if isCatalogItem(rootFlag, include.path) {
+				innerIncludes, err = getMergeList(include.path)
+				// Remove last element, which is the current file
+				innerIncludes = innerIncludes[:len(innerIncludes)-1]
+				if err != nil {
+					return []Include{}, done, err
+				}
+			} else {
+				innerIncludes, innerDone, err = parseAllIncludes(include.path, done)
+				done = innerDone
+				if err != nil {
+					return []Include{}, done, err
+				}
 			}
 
 			innerIncludes = append(innerIncludes, include)

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -396,40 +396,46 @@ func mergeVars(p string, mergeStrategies []MergeStrategy) (map[string]any, []Inc
 
 	// Add related file content
 	if config.initialized {
-		for _, related := range config.RelatedFilesV2 {
-			if related.LoadInto != "" {
-				if related.ContentKey == "" {
-					logErr.Fatalf("Related file %s has no content key", related.File)
-				}
-				dir := filepath.Dir(p)
-				relatedPath := filepath.Join(dir, related.File)
-				if !fileExists(relatedPath) {
-					continue
-				}
-				content := map[string]any{}
-				for k, v := range related.Set {
-					content[k] = v
-				}
-				relatedContent, err := os.ReadFile(relatedPath)
-				if err != nil {
-					logErr.Fatalf("Error reading related file %s: %v", relatedPath, err)
-				}
-				temp := map[string]any{}
+		for _, include := range mergeList {
+			if !isCatalogItem(rootFlag, include.path) {
+				continue
+			}
 
-				content[related.ContentKey] = string(relatedContent)
-				if err := SetRelative(temp, related.LoadInto, content); err != nil {
-					logErr.Fatalf("Error SetRelative: %v", err)
-				}
+			for _, related := range config.RelatedFilesV2 {
+				if related.LoadInto != "" {
+					if related.ContentKey == "" {
+						logErr.Fatalf("Related file %s has no content key", related.File)
+					}
+					dir := filepath.Dir(include.path)
+					relatedPath := filepath.Join(dir, related.File)
+					if !fileExists(relatedPath) {
+						continue
+					}
+					content := map[string]any{}
+					for k, v := range related.Set {
+						content[k] = v
+					}
+					relatedContent, err := os.ReadFile(relatedPath)
+					if err != nil {
+						logErr.Fatalf("Error reading related file %s: %v", relatedPath, err)
+					}
+					temp := map[string]any{}
 
-				// Merge temp into final using mergo
-				if err := mergo.Merge(
-					&final,
-					temp,
-					mergo.WithOverride,
-					mergo.WithOverwriteWithEmptyValue,
-					mergo.WithAppendSlice,
-				); err != nil {
-					return final, mergeList, err
+					content[related.ContentKey] = string(relatedContent)
+					if err := SetRelative(temp, related.LoadInto, content); err != nil {
+						logErr.Fatalf("Error SetRelative: %v", err)
+					}
+
+					// Merge temp into final using mergo
+					if err := mergo.Merge(
+						&final,
+						temp,
+						mergo.WithOverride,
+						mergo.WithOverwriteWithEmptyValue,
+						mergo.WithAppendSlice,
+					); err != nil {
+						return final, mergeList, err
+					}
 				}
 			}
 		}

--- a/cli/merge_test.go
+++ b/cli/merge_test.go
@@ -178,6 +178,29 @@ func BenchmarkMergeJSON(b *testing.B) {
 	}
 }
 
+func TestMergeCatalogItemIncluded(t *testing.T) {
+	initLoggers()
+	rootFlag = abs("fixtures")
+	initConf(rootFlag)
+	initSchemaList()
+	initMergeStrategies()
+	validateFlag = true
+	merged, _, err := mergeVars(
+		"fixtures/test/foo/prod.yaml",
+		mergeStrategies,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, value, _, err := Get(merged, "/__meta__/catalog/description")
+	if err != nil {
+		t.Error(err)
+	}
+	if value != "from description.adoc\n" {
+		t.Error("description is not 'from description.adoc'", value)
+	}
+}
 func TestMerge(t *testing.T) {
 	initLoggers()
 	rootFlag = abs("fixtures")


### PR DESCRIPTION
This change, if applied, allows using other catalog items as included files.

ex:

```yaml
#include /sandboxes-gpte/OCP412_SINGLE_NODE/prod.yaml

__meta__:
  catalog:
    display_name: Example for Community Demo
    labels:
      Provider: RH_Community
      SLA: Community
```

- Automatically load common and included files of the included catalog item
- related files (description, service templates, etc) are automatically injected, in order

Full Test done against v0.7.1:

```
../tools/test_new_version.sh ~/sync/dev/agnosticv ~/bin/agnosticv.v0.7.1
~/bin/agnosticv.include.ci
```

Add unit test to cover the case.