### PR TITLE
Fix order of the inner Include List inside a file

### DIFF
--- a/cli/agnosticv_test.go
+++ b/cli/agnosticv_test.go
@@ -262,7 +262,7 @@ func TestWalk(t *testing.T) {
 		{
 			description: "No JMES filtering",
 			hasFlags:    []string{},
-			count:       12,
+			count:       13,
 		},
 		{
 			description:  "Related includes/include1.yaml",
@@ -298,7 +298,7 @@ func TestWalk(t *testing.T) {
 			hasFlags:       []string{},
 			relatedFlags:   []string{"includes/include1.yaml"},
 			orRelatedFlags: []string{"common.yaml"},
-			count:          12,
+			count:          13,
 		},
 		{
 			description:    "Related (exclusive + inclusive) to /common.yaml and --has flag",
@@ -320,7 +320,7 @@ func TestWalk(t *testing.T) {
 		{
 			description: "Is a Babylon catalog item",
 			hasFlags:    []string{"__meta__.catalog"},
-			count:       12,
+			count:       13,
 		},
 		{
 			description: "env_type is clientvm and purpose is development",

--- a/cli/fixtures/includes/order1.yaml
+++ b/cli/fixtures/includes/order1.yaml
@@ -1,0 +1,3 @@
+---
+foo: include1
+bar: include1

--- a/cli/fixtures/includes/order2.yaml
+++ b/cli/fixtures/includes/order2.yaml
@@ -1,0 +1,6 @@
+---
+#include order21.yaml
+#include order22.yaml
+#include order23.yaml
+foo: include2
+bar: include2

--- a/cli/fixtures/includes/order21.yaml
+++ b/cli/fixtures/includes/order21.yaml
@@ -1,0 +1,2 @@
+foo: include21
+bar: include21

--- a/cli/fixtures/includes/order22.yaml
+++ b/cli/fixtures/includes/order22.yaml
@@ -1,0 +1,1 @@
+bar: include22

--- a/cli/fixtures/includes/order23.yaml
+++ b/cli/fixtures/includes/order23.yaml
@@ -1,0 +1,1 @@
+bar: include23

--- a/cli/fixtures/includes/order3.yaml
+++ b/cli/fixtures/includes/order3.yaml
@@ -1,0 +1,3 @@
+---
+foo: include3
+bar: include3

--- a/cli/fixtures/test/foo/order.yaml
+++ b/cli/fixtures/test/foo/order.yaml
@@ -1,0 +1,5 @@
+---
+#include ../../includes/order1.yaml
+#include ../../includes/order2.yaml
+#include ../../includes/order3.yaml
+bar: order.yaml

--- a/cli/includes.go
+++ b/cli/includes.go
@@ -203,7 +203,7 @@ func parseAllIncludes(path string, done map[string]bool) ([]Include, map[string]
 			}
 
 			innerIncludes = append(innerIncludes, include)
-			result = append(innerIncludes, result...)
+			result = append(result, innerIncludes...)
 		}
 	}
 	return result, done, nil

--- a/cli/merge_test.go
+++ b/cli/merge_test.go
@@ -201,6 +201,40 @@ func TestMergeCatalogItemIncluded(t *testing.T) {
 		t.Error("description is not 'from description.adoc'", value)
 	}
 }
+
+func TestMergeCatalogItemIncludedWithOrder(t *testing.T) {
+	initLoggers()
+	rootFlag = abs("fixtures")
+	initConf(rootFlag)
+	initSchemaList()
+	initMergeStrategies()
+	validateFlag = true
+	merged, _, err := mergeVars(
+		"fixtures/test/foo/order.yaml",
+		mergeStrategies,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, value, _, err := Get(merged, "/foo")
+	if err != nil {
+		t.Error(err)
+	}
+	if value != "include3" {
+		t.Error("foo should be 'include3'", value)
+	}
+
+	_, value, _, err = Get(merged, "/bar")
+	if err != nil {
+		t.Error(err)
+	}
+	if value != "order.yaml" {
+		t.Error("bar should be 'order.yaml'", value)
+	}
+}
+
+
 func TestMerge(t *testing.T) {
 	initLoggers()
 	rootFlag = abs("fixtures")
@@ -256,10 +290,10 @@ func TestMerge(t *testing.T) {
 		"/common.yaml",
 		"/test/account.yaml",
 		"/test/BABYLON_EMPTY_CONFIG_AWS/common.yaml",
-		"/includes/include2.meta.yml",
 		"/includes/include1.meta.yaml",
 		"/includes/include1.yaml",
 		"/test/BABYLON_EMPTY_CONFIG_AWS/test.meta.yaml",
+		"/includes/include2.meta.yml",
 		"/test/BABYLON_EMPTY_CONFIG_AWS/test.yaml",
 	}
 	for i, v := range expectedMergeList {
@@ -282,6 +316,34 @@ func TestMerge(t *testing.T) {
 	found, value, _, err = Get(merged, "/__meta__/from_include1_meta")
 	if !found || err != nil || value != "value1" {
 		t.Error("/__meta__/from_include1_meta  be merged from detected meta")
+	}
+
+	merged, includeList, err = mergeVars(
+		"fixtures/test/foo/order.yaml",
+		mergeStrategies,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedMergeList = []string{
+		"/common.yaml",
+		"/test/account.yaml",
+		"/includes/order1.yaml",
+		"/includes/order21.yaml",
+		"/includes/order22.yaml",
+		"/includes/order23.yaml",
+		"/includes/order2.yaml",
+		"/includes/order3.yaml",
+		"/test/foo/order.yaml",
+
+	}
+	for i, v := range expectedMergeList {
+		if !strings.HasSuffix(includeList[i].path, v) {
+			t.Error(v, "not at the position", i, "in the merge list of ",
+				"fixtures/test/foo/order.yaml",
+				"found", includeList[i].path, "instead")
+		}
 	}
 }
 


### PR DESCRIPTION
jira: GPTEINFRA-7360

Inside a file, order of includes should be followed.
When adding includes to a catalog item:

```
#include A
#include B
```
Vars from B should be merged after vars from A. The include list must follow the order.

This change includes:

* Fix the parseAllIncludes function
* Add tests to ensure order of innerIncludes are correct