### PR TITLE
Perf improvement: process '-has' flag at the end

### DIFF
--- a/cli/agnosticv.go
+++ b/cli/agnosticv.go
@@ -446,6 +446,32 @@ func findCatalogItems(workdir string, hasFlags []string, relatedFlags []string, 
 					}
 
 					if containsPath(related, orRelatedAbs) {
+						if len(hasFlags) > 0 {
+							logDebug.Println("hasFlags", hasFlags)
+							// Here we need yaml.v3 in order to use jmespath
+							merged, _, err := mergeVars(p, mergeStrategies)
+							if err != nil {
+								// Print the error and move to next file
+								logErr.Println(err)
+								return nil
+							}
+
+							for _, hasFlag := range hasFlags {
+								r, err := jmespath.Search(hasFlag, merged)
+								if err != nil {
+									logErr.Printf("ERROR: JMESPath '%q' not correct, %v", hasFlag, err)
+									return err
+								}
+
+								logDebug.Printf("merged=%#v\n", merged)
+								logDebug.Printf("r=%#v\n", r)
+
+								// If JMESPath expression does not match, skip file
+								if r == nil || r == false {
+									return nil
+								}
+							}
+						}
 						// Add catalog item to result
 						result = append(result, p)
 						return nil

--- a/cli/agnosticv.go
+++ b/cli/agnosticv.go
@@ -424,33 +424,6 @@ func findCatalogItems(workdir string, hasFlags []string, relatedFlags []string, 
 			return nil
 		}
 
-		if len(hasFlags) > 0 {
-			logDebug.Println("hasFlags", hasFlags)
-			// Here we need yaml.v3 in order to use jmespath
-			merged, _, err := mergeVars(p, mergeStrategies)
-			if err != nil {
-				// Print the error and move to next file
-				logErr.Println(err)
-				return nil
-			}
-
-			for _, hasFlag := range hasFlags {
-				r, err := jmespath.Search(hasFlag, merged)
-				if err != nil {
-					logErr.Printf("ERROR: JMESPath '%q' not correct, %v", hasFlag, err)
-					return err
-				}
-
-				logDebug.Printf("merged=%#v\n", merged)
-				logDebug.Printf("r=%#v\n", r)
-
-				// If JMESPath expression does not match, skip file
-				if r == nil || r == false {
-					return nil
-				}
-			}
-		}
-
 		if len(relatedFlags) > 0 || len(orRelatedFlags) > 0 {
 			mergeList, err := getMergeList(pAbs)
 			related := extendMergeListWithRelated(pAbs, mergeList)
@@ -495,6 +468,33 @@ func findCatalogItems(workdir string, hasFlags []string, relatedFlags []string, 
 						return nil
 					}
 
+				}
+			}
+		}
+
+		if len(hasFlags) > 0 {
+			logDebug.Println("hasFlags", hasFlags)
+			// Here we need yaml.v3 in order to use jmespath
+			merged, _, err := mergeVars(p, mergeStrategies)
+			if err != nil {
+				// Print the error and move to next file
+				logErr.Println(err)
+				return nil
+			}
+
+			for _, hasFlag := range hasFlags {
+				r, err := jmespath.Search(hasFlag, merged)
+				if err != nil {
+					logErr.Printf("ERROR: JMESPath '%q' not correct, %v", hasFlag, err)
+					return err
+				}
+
+				logDebug.Printf("merged=%#v\n", merged)
+				logDebug.Printf("r=%#v\n", r)
+
+				// If JMESPath expression does not match, skip file
+				if r == nil || r == false {
+					return nil
 				}
 			}
 		}


### PR DESCRIPTION
The `--has` flag is costly because it forces variables to be merged. When looping over a lot of catalog items, it can slow down the command a lot.

Move its processing at the last position when filtering catalog items, so it's executed less often when used in combination of other flags.

This will help in agnosticv-operator.
Here is the improvement from **5s** to **0.5s** of execution time for a command:

```
agnosticv on  master [$?] via 🐍 v3.11.8
❯ time agnosticv.v0.8.0 --list --has=__meta__ --dir $PWD --related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/common.yaml --or-related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/description.html --or-related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/dev.yaml --or-related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/info-message-template.adoc

real    0m5.222s
user    0m5.411s
sys     0m0.427s

❯ time agnosticv_dev --list --has=__meta__ --dir $PWD --related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/common.yaml --or-related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/description.html --or-related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/dev.yaml --or-related sandboxes-gpte/ANS_BU_WKSP_JUST_SATELLITE/info-message-template.adoc

real    0m0.499s
user    0m0.404s
sys     0m0.125s
```